### PR TITLE
Fix typos and grammatical errors throughout manuscript

### DIFF
--- a/tex/fig/ablation-site-counts.tex
+++ b/tex/fig/ablation-site-counts.tex
@@ -13,7 +13,7 @@
 \end{subfigure}
 \caption{
     \textbf{Genome size and task coding site count outcomes across slip-duplication ablation treatments.}
-    \small Violin plots show genome size (panel \ref{fig:ablation-site-counts:coding-site-counts}) and number of task coding sites (panel \ref{fig:ablation-site-counts:coding-site-counts}) in final dominant genotypes.
+    \small Violin plots show genome size (panel \ref{fig:ablation-site-counts:genome-size}) and number of task coding sites (panel \ref{fig:ablation-site-counts:coding-site-counts}) in final dominant genotypes.
     % https://github.com/chaynes2019/AvidaGeneDupe/blob/ecb7a0506d4233e57c0f7002b19ea09008dba847/binder/fig-3-static-genomelength.ipynb
     % https://github.com/chaynes2019/AvidaGeneDupe/blob/ecb7a0506d4233e57c0f7002b19ea09008dba847/binder/fig-3-static-num-coding-sites.ipynb
     Two-tailed Kruskal-Wallis tests indicate significant between-treatment variation in both genome size ($H = 130$, $p << 0.001$) and number of task coding sites ($H = 135$, $p << 0.001$).

--- a/tex/fig/nulldist.tex
+++ b/tex/fig/nulldist.tex
@@ -23,7 +23,7 @@
         \textbf{Distribution of slip-insertion mutation outcomes.}
         \footnotesize
         Outcomes were measured by applying random slip-insertion to genomes sampled from along line-of-descent for final-dominant genotype over slip-duplication treatment lineage histories for slip-duplicate trials.
-        Notably, insertion mutations that neither add or lose tasks tend to increase robustness by reducing the number of task-critical coding sites --- particularly for genomes that have acquired complex tasks.
+        Notably, insertion mutations that neither add nor lose tasks tend to increase robustness by reducing the number of task-critical coding sites --- particularly for genomes that have acquired complex tasks.
         Unsurprisingly, deleterious mutations tend to greatly decrease coding site count and beneficial mutations, which add new tasks, tend to increase them.
         Error bars give bootstrapped 95\% CI.
     }

--- a/tex/fig/num-coding-sites.tex
+++ b/tex/fig/num-coding-sites.tex
@@ -34,7 +34,7 @@
         Generation-by-generation counts of coding sites over evolutionary history, measured by single-site knockouts.
         Gene duplication yields active coding site counts comparable to long-genome control (panel \ref{fig:num-coding-sites:active}).
         Vestigial coding sites were labeled as active in an ancestor, but are no longer active coding sites.
-        Vestigial coding site count under slip-duplication treatment outpace control treatments (panel \ref{fig:num-coding-sites:vestigial}).
+        Vestigial coding site counts under slip-duplication treatment outpace control treatments (panel \ref{fig:num-coding-sites:vestigial}).
         Panel \ref{fig:num-coding-sites:total} gives total genome size.
         Solid bands give 95\% CI, bootstrapped over 30 replicates per treatment.
         Hatched band gives full range of genome sizes observed.

--- a/tex/fig/potentiation.tex
+++ b/tex/fig/potentiation.tex
@@ -7,7 +7,7 @@ angle=90
   \textbf{Duplications provide \textit{de novo} coding sites for complex traits.}
   \footnotesize
   Enrichment tabulates density of coding sites for phenotype traits in duplicated regions, normalized to neutral expectation.
-  Values greater than 1 indicate that coding are ocerrepresented in duplicated regions, compared to their background frequency.
+  Values greater than 1 indicate that coding sites are overrepresented in duplicated regions, compared to their background frequency.
   Each observation gives enrichment of coding site density within duplicated regions at the first completion of an available task; observation counts are 48, 56, 59, 52, and 20.
   Significance of deviation from null expectation of median value 1.0 is indicated with * ($p < 0.05$), ** ($p < 0.01$), or *** ($p < 0.001$) (one-tailed Wilcoxon signed-rank test).
 } \label{fig:potentiation}

--- a/tex/fig/slip_mut_variants.tex
+++ b/tex/fig/slip_mut_variants.tex
@@ -6,7 +6,7 @@
 \caption{%
 \textbf{Replication, gene duplication, and task complexity in Avida.}
 \footnotesize
-Self-replicating computer programs serve as genomes of digital ``model organisms'' (middle left), competing to survive and reproduce occurs in a fixed-capacity population (bottom).
+Self-replicating computer programs serve as genomes of digital ``model organisms'' (middle left), competing to survive and reproduce in a fixed-capacity population (bottom).
 Available ``metabolic'' input/output tasks, varying in NAND-complexity, can accelerate replication (top).
 An organism's metabolic ``phenotype'' arises from the expression of its genetic code.
 When copied from parent to offspring, this genetic code may be subject to slip insertions, which insert an exact copy of a target segment (A, middle left), or slip deletions, which excise a target segment.

--- a/tex/text/body/conclusion.tex
+++ b/tex/text/body/conclusion.tex
@@ -17,13 +17,12 @@ Such work can also inform questions around universal properties of life \citep{d
 
 % future work:
 Results presented here motivate several future studies.
-Performing deeper, play-by-play analyses of individual lineages evolved with gene duplications could allow us to identify examples of subfunctionalization or neofunctionalization, and deepen our understanding of  their contributions to promoting the evolution of complex features through a case study approach \citep{mcphee2018detailed}.
+Performing deeper, play-by-play analyses of individual lineages evolved with gene duplications could allow us to identify examples of subfunctionalization or neofunctionalization, and deepen our understanding of their contributions to promoting the evolution of complex features through a case study approach \citep{mcphee2018detailed}.
 Future work might also extend our retrospective approach for detecting potentiation into full-fledged replay experiments, where replicate evolutionary trajectories are collected to directly identify the statistical impact of evolutionary events in influencing later evolutionary outcomes \citep{blount2018contingency,Ferguson2023}.
 Such efforts will further help establish the role that gene duplication plays in natural evolution and could play in computational systems.
 
 % application-oriented outcomes:
 While evolutionary studies are essential for understanding the natural world around us, evolution can also be harnessed for applied purposes.
-Within the domain of evolutionary computation.
 Findings from our work can help guide the development of more effective algorithms for evolutionary computation, where evolution-inspired approaches are applied to real-world engineering challenges \citep{holland1992genetic}.
 Aspects of these findings may also generalize to bioengineering via directed evolution, in informing approaches to targeted mutagenesis \citep{sandberg2019emergence}.
 

--- a/tex/text/body/introduction.tex
+++ b/tex/text/body/introduction.tex
@@ -7,7 +7,7 @@ In this paper, we use direct experimentation to test how gene duplication impact
 % Mirroring larger questions around the adaptive framings of evolutionary origins of biological complexity, gene duplication is thought to lead to increased complexity both by increasing opportunities for the accumulation of contingent complexity (``sub-functionalization'') and by facilitating adaptive discovery of beneficial novel traits (``neo-functionalization'').
 In recent years, such experimental approaches --- which can explicitly test causality --- have become an important complement to observational studies of natural history \citep{Kawecki2012,Elena2003}.
 In the context of gene duplication, microbial experiments have confirmed the adaptive significance of duplicative dose effects \citep{Tong2025,Dhar2014,Nsvall2012}.
-Another notable microbial experiment has tested how gene copy count affects evolutionary innovation \citet{mihajlovic2025direct}.
+Another notable microbial experiment has tested how gene copy count affects evolutionary innovation \citep{mihajlovic2025direct}.
 Comparing evolution of fluorescence phenotypes between single- and double-copy coGFP populations, the latter populations exhibited greater robustness under mutation but no faster adaptive change under selection.
 As the authors highlight, though, practical constraints required they impose mutation rates and selection pressures far removed from natural evolution.
 
@@ -23,7 +23,7 @@ We conducted digital experiments using Avida, software which administers populat
 Because copy errors introduce heritable variation in how efficiently programs replicate, evolution by natural selection results \citep{pennock2007models}.
 
 In early work with Avida, Lenski \textit{et al.} established a useful framework for studying phenotypic traits across a well-defined spectrum of complexity;
-input/output calculations can be treated as phenotypic traits, with the complexity of a given trait given according to its minimum necessary substeps.
+input/output calculations can be treated as phenotypic traits, with the complexity of a given trait determined according to its minimum necessary substeps.
 Applying this lens, Lenski \textit{et al.} demonstrated that simpler traits could provide building blocks for complex ones --- and, in fact, often amounted to necessary prerequisites for their evolution \citep{Lenski2003Evolutionary}.
 
 To complement the above phenotypic measure of functional complexity, we also established a genetic measure of structural complexity.

--- a/tex/text/body/methods.tex
+++ b/tex/text/body/methods.tex
@@ -14,7 +14,7 @@ We configured available metabolic resources consisting of tasks NOT, NAND, OR-NO
 Identical reward was provided for performing each task and kept consistent throughout trials.
 Rewards accrued independently for each task, allowing fitness benefits to be compounded by performing multiple tasks.
 In some analyses, we report a count of adaptive phenotypic traits, ranging from a minimum of 0 (\textit{i.e.,} the organism performs no tasks and receives no reward) to a maximum of 9 (\textit{i.e.,} the organism performs all 9 available tasks and receives the maximum reward).
-As a metric of complexity, logic tasks were categorized by minimum required NAND operations (Figure \ref{fig:slip_mut_variants}; \citep{Lenski2003Evolutionary}).
+As a metric of complexity, logic tasks were categorized by minimum required NAND operations (Figure \ref{fig:slip_mut_variants}; \citealp{Lenski2003Evolutionary}).
 
 Except where otherwise noted, experiments began with a 100-instruction ancestral self-replicator.
 In all cases, mutations reducing genome size below 100 instructions were disallowed to ensure sufficient genetic material for phenotypic traits.
@@ -82,7 +82,7 @@ Adaption outcomes shown in Figure \ref{fig:results_panels} were also derived fro
 For experiments incorporating the long-genome baseline control, timecourses of adaptive evolution were compared in terms of generations, rather than in terms of updates (simulation timesteps).
 This strategy was necessary to account for the long-genome controls elapsing on the order of 10$\times$ fewer generations than baseline conditions, since self-replication is slower for longer genomes.
 In other experiments, control treatments generally elapsed at least as many generations as the slip-duplication experimental treatment, on account of comparable or shorter genome lengths.
-Thus, comparing by update remains conservative as faster adaptation under \textit{slip-duplication} occured without more generations elapsing.
+Thus, comparing by update remains conservative as faster adaptation under \textit{slip-duplication} occurred without more generations elapsing.
 % % Slip-duplicate treatment
 % The \textbf{slip-duplicate treatment} allowed for mutation events that resulted in full code duplications via the slip-duplicate mutation operator. Duplications in this treatment preserved both the content and the structure of duplicated code. This allowed us to answer the following question: how important is it that gene duplications can exactly duplicate sequences in a genome in both content \textit{and} structure?
 

--- a/tex/text/body/results-and-discussion.tex
+++ b/tex/text/body/results-and-discussion.tex
@@ -16,7 +16,7 @@ However, disaggregating by task complexity reveals that genome size's adaptive b
 For traits requiring 3 or fewer NANDs, adaptation in the long-genome control matched or exceeded gene duplication when compared generation-by-generation (Figure \ref{fig:adaptive-evolution-rate}).
 By contrast, increased genome size alone failed to match duplication in promoting complex 4- and 5-NAND traits (Fisher's exact tests; 36/60 vs. 24/60, $p<0.05$ [4 components]; 10/30 vs. 2/30, $p<0.03$ [5 components]; Figure \ref{fig:adaptive-evolution-rate}).
 % https://github.com/chaynes2019/AvidaGeneDupe/blob/538ede79c7301f10718ca96c8dd38782b6882632/binder/adaptive-evolution-rate.ipynb
-Thus, in this case, duplication specifically advantaged complex adaptaiton.
+Thus, in this case, duplication specifically advantaged complex adaptation.
 
 % ---
 % @AML: Moved to discussion
@@ -166,7 +166,7 @@ Leveraging the unique tractability of our study system, we were able to explore 
 
 \subsection{Gene duplication facilitates adaptive evolution of complex traits}
 
-Adaption by gene duplication in our study system corroborates findings across a wide variety of biological taxa and digital models \citep{Koza:1995fr,Zhang:2003fw,Teichmann:2004cz}.
+Adaptation by gene duplication in our study system corroborates findings across a wide variety of biological taxa and digital models \citep{Koza:1995fr,Zhang:2003fw,Teichmann:2004cz}.
 Indeed, a striking example of gene duplication potentiating novel adaptation comes from the Long-Term Evolution Experiment in \textit{E. coli} \citep{lenski1991longterm,Lenski2003phenotypic}, where a duplication in one population enabled expression of a key citrate transporter in aerobic conditions --- resulting in a seven-fold increase in carrying capacity within experimental conditions \citep{blount_genomic_2012}.
 Among many other examples from natural history \citep{zhang2002adaptive,gaines2009gene,perry2007diet,hittinger2007gene,benderoth2006positive,dulai1999evolution,Ogino2015}, such observations underlie longstanding theory connecting gene duplication and adaptive traits, dating as far back as \citet{ohno1970evolution}.
 
@@ -193,7 +193,7 @@ Unlike our long-genome control, no adaptive benefit arose from neutral inserts (
 Despite apparent opportunity for increased genome length to advantage adaptation, relatively few neutral inserts accumulated.
 Gene duplication induced much greater genome expansion than neutral inserts --- by a factor of nearly 4$\times$, despite equivalent site-creation potential (Supplementary Figure~\ref{fig:ablation-site-counts}).
 One possible explanation is selection against the mutational load arising from additional genome sites.
-Indeed, in preliminary experiments we found mutational load frequently drove shrinkage of founding ancestors' genome neutral genome content.
+Indeed, in preliminary experiments we found mutational load frequently drove shrinkage of founding ancestors' neutral genome content.
 This behavior supports theory that ``lock-in'' by dose effects or contingent interdependencies (e.g., ``complexity ratchet'' effects \citep{Liard2020,Soyer2006,Luke2011,gould1996full}) are essential to retention of new genome content \citep{Innan2010,Wagner1998,Tautz1992,Force1999,Bergthorsson2007}.
 
 \subsection{Duplicated sites are potentiated for later adaptation}


### PR DESCRIPTION
## Summary
This PR corrects numerous spelling, grammatical, and typographical errors throughout the manuscript text and figure captions.

## Key Changes
- **Spelling corrections:**
  - "adaptaiton" → "adaptation" (results-and-discussion.tex)
  - "Adaption" → "Adaptation" (results-and-discussion.tex)
  - "occured" → "occurred" (methods.tex)
  - "ocerrepresented" → "overrepresented" (potentiation.tex)

- **Grammatical fixes:**
  - "genome neutral genome content" → "neutral genome content" (results-and-discussion.tex, removed redundant word)
  - "neither add or lose" → "neither add nor lose" (nulldist.tex)
  - "Vestigial coding site count" → "Vestigial coding site counts" (num-coding-sites.tex, subject-verb agreement)
  - "competing to survive and reproduce occurs" → "competing to survive and reproduce" (slip_mut_variants.tex, removed redundant verb)

- **Citation format corrections:**
  - "\citet{mihajlovic2025direct}" → "\citep{mihajlovic2025direct}" (introduction.tex, corrected citation command)
  - "\citep{Lenski2003Evolutionary}" → "\citealp{Lenski2003Evolutionary}" (methods.tex, changed to author-list-only format)

- **Reference label corrections:**
  - Fixed incorrect figure panel reference in ablation-site-counts.tex caption (panel reference was duplicated)

- **Text cleanup:**
  - Removed incomplete sentence fragment "Within the domain of evolutionary computation." (conclusion.tex)
  - Fixed spacing issue in conclusion.tex ("understanding of  their" → "understanding of their")

## Notes
All changes are non-substantive corrections that improve clarity and correctness without altering the scientific content or meaning of the manuscript.

https://claude.ai/code/session_012fNhLTKpdHsM8uNVfdvUWV